### PR TITLE
fix docker push workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -150,11 +150,7 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags \
-          | map(select(startswith("${{ env.IMAGE }}")) \
-          | "-t " + .) \
-          | join(" ")' /tmp/bake-meta.json) $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+        run: docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.IMAGE }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) $(printf '${{ env.IMAGE }}@sha256:%s ' *)  # yamllint disable-line rule:line-length
 
       - name: Inspect image
         run: docker buildx imagetools inspect ${{ env.IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)  # yamllint disable-line rule:line-length


### PR DESCRIPTION
closes #69 
unsplitted the run command, didn't work as intended.
added yamllint exception for the line to make linter happy.
merging the images should no longer fail and hopefully it will push to dockerhub. :)