### PR TITLE
send content-length headers for static content

### DIFF
--- a/src/dns_exporter/exporter.py
+++ b/src/dns_exporter/exporter.py
@@ -691,16 +691,20 @@ class DNSExporter(MetricsHandler):
         elif self.url.path == "/":
             # return a basic index page
             self.send_response(200)
+            self.send_header("content-length", str(len(INDEX.encode("utf-8"))))
             self.end_headers()
             self.wfile.write(INDEX.encode("utf-8"))
             dnsexp_http_responses_total.labels(path="/", response_code=200).inc()
             logger.debug("Returning index page for request to /")
+            # self.close()
 
         # unknown endpoint
         else:
             self.send_response(404)
+            msg = b"404 not found"
+            self.send_header("content-length", str(len(msg)))
             self.end_headers()
-            self.wfile.write(b"404 not found")
+            self.wfile.write(msg)
             dnsexp_http_responses_total.labels(
                 path=self.url.path,
                 response_code=404,


### PR DESCRIPTION
I was using the / endpoint for health-checks in kubernetes. After a short while I noticed LOTs of connections stuck in timewait and the server was unresponsive via curl.  I noticed this reference which makes sense https://github.com/prometheus/client_python/issues/299 .  Essentially the response either needs to use a chunked encoding, send a content length, or explicitly close the connection after sending the response (http/1.0 style).

Thanks for putting this tool together.  It's exactly what I needed.