### PR TITLE
only run on succesful tests

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - 'v*'
+  workflow_run:
+    workflows: [Run Tox]
+    types:
+      - completed
 
 env:
   REGISTRY_IMAGE: tykling/dns_exporter

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,6 +5,10 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - 'v*'
+  workflow_run:
+    workflows: [Run Tox]
+    types:
+      - completed
 
 # https://docs.pypi.org/trusted-publishers/using-a-publisher/
 jobs:


### PR DESCRIPTION
this should now only push to docker hub and pypi when tagging and also completed tests