### PR TITLE
adds IGNORECASE to check_regexes as case should not matter

### DIFF
--- a/src/dns_exporter/collector.py
+++ b/src/dns_exporter/collector.py
@@ -599,7 +599,7 @@ class DNSCollector(Collector):
         num_matches_per_rrs = {str(rr): 0 for rr in rrs}
 
         for regex in getattr(validators, validator):
-            p = re.compile(regex, re.IGNORECASE)
+            p = re.compile(regex)
             for rr in rrs:
                 result = p.match(str(rr))
                 log_entry = f"matching '{rr}' against '{regex}': " + ("success" if result else "failed")

--- a/src/docs/source/configuration.rst
+++ b/src/docs/source/configuration.rst
@@ -249,6 +249,8 @@ The default value is ``5.0``.
 ~~~~~~~~~~~~~~~~~~~~~~~
 This setting defines validation rules for the ``ANSWER`` section of the DNS response. ``validate_answer_rrs`` can do the following validations:
 
+To use case insensitive matching in the regex expression, it is necessary to use the prefix ``(?i)`` in the regular expression.
+
 ``fail_if_matches_regexp``
    A list of regular expressions. Each RR in the ``ANSWER`` section is checked against each regular expression in the list. The query is considered failed if a match is found.
 

--- a/src/tests/test_validators.py
+++ b/src/tests/test_validators.py
@@ -369,7 +369,7 @@ def test_validate_rrs_fail_if_none_matches_regexp_3(dns_exporter_example_config,
         ([".*127.0.0.1"], does_not_raise()),
         ([".*127.0.0.1", "192.168.32.42"], does_not_raise()),
         ([".*beef.*"], pytest.raises(ValidationError)),
-        ([".*BEEF.*"], pytest.raises(ValidationError)),
+        (["(?i).*BEEF.*"], pytest.raises(ValidationError)),
         ([".*c0DE.*"], does_not_raise()),
     ],
 )
@@ -397,7 +397,7 @@ def test_fail_if_matches_regexp(regex_list, expectation, caplog):
     ("regex_list", "expectation"),
     [
         ([".*"], pytest.raises(ValidationError)),
-        ([".*10.8.23.42", ".*CNAME.*", ".*BEEF.*"], pytest.raises(ValidationError)),
+        ([".*10.8.23.42", ".*CNAME.*", "(?i).*BEEF.*"], pytest.raises(ValidationError)),
         ([".*10.8.23.42"], does_not_raise()),
         ([".*127.0.0.1"], does_not_raise()),
         ([".*127.0.0.1", ".*CNAME.*"], does_not_raise()),
@@ -461,7 +461,8 @@ def test_fail_if_not_matches_regexp(regex_list, expectation, caplog):
         ([".*10.8.23.42", ".*CNAME.*"], does_not_raise()),
         ([".*10.8.23.42", ".*127.0.0.1"], does_not_raise()),
         ([".*127.0.0.1"], pytest.raises(ValidationError)),
-        ([".*127.0.0.1", ".*ABC"], does_not_raise()),
+        ([".*127.0.0.1", "(?i).*ABC"], does_not_raise()),
+        ([".*127.0.0.1", ".*ABC"], pytest.raises(ValidationError)),
         ([".*127.0.0.1", ".*XYZ"], pytest.raises(ValidationError)),
     ],
 )


### PR DESCRIPTION
This PR improves the regex matching for `DNSCollector. check_regexes` in order to ignore case while validating answers.

This was defined with [RFC4343](https://datatracker.ietf.org/doc/html/rfc4343#section-3).