### PR TITLE
chore: update digestabot action

### DIFF
--- a/.github/workflows/digestabot.yml
+++ b/.github/workflows/digestabot.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Update Docker image digests
-        uses: chainguard-dev/digestabot@v1.2.3
+        uses: chainguard-dev/digestabot@afe360aa3b0c29d88844138e8fa0349384398967  # v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 ...


### PR DESCRIPTION
for some reason this wasn't updated by dependabot.
this updates digestabot action to latest version